### PR TITLE
Add some config options.

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -11,7 +11,10 @@ exports.onRenderBody = function handleRenderBody(
 ) {
   const options = getOptions(pluginOptions);
   if (options.isEnabled) {
-    const { apikey } = options;
+    const { apikey, parselyCDN } = options;
+
+    // pixelHost needs double-quotes because of how it'll be embedded.
+    const pixelHost = options.pixelHost ? `"${options.pixelHost}"` : null;
 
     return setHeadComponents([
       <script
@@ -19,7 +22,7 @@ exports.onRenderBody = function handleRenderBody(
         id="parsely-cfg"
         async
         defer
-        src={`//cdn.parsely.com/keys/${apikey}/p.js`}
+        src={`//${parselyCDN}/keys/${apikey}/p.js`}
       />,
       <script
         key="gatsby-plugin-parsely-analytics-onload"
@@ -28,6 +31,7 @@ exports.onRenderBody = function handleRenderBody(
           window.PARSELY = {
             pageviewQueue: [],
             autotrack: false,
+            pixelhost: ${pixelHost},
             onload: function() {
               for (var i = 0; i < window.PARSELY.pageviewQueue.length; i++) {
                 PARSELY.beacon.trackPageView(window.PARSELY.pageviewQueue[i]);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,8 @@
 const DEFAULT_OPTIONS = {
   apikey: null,
-  enableInDevelopment: false
+  enableInDevelopment: false,
+  parselyCDN: "cdn.parsely.com",
+  pixelHost: null
 };
 
 export function getOptions(pluginOptions) {
@@ -15,7 +17,7 @@ export function getOptions(pluginOptions) {
 export function absoluteUrlForLocation(location) {
   return `${window.location.protocol}//${window.location.host}${
     location.pathname
-  }${location.search}${location.hash}`;
+    }${location.search}${location.hash}`;
 }
 
 function parselyTrackPageViewExists() {


### PR DESCRIPTION
These will make some debugging tasks easier for Parse.ly devs. They aren't being added to the documentation because the average user will never need to touch these.