### PR TITLE
fix referrer thing, also put JS in body not head as per docs

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -13,7 +13,7 @@ exports.onRouteUpdate = function handleRouteUpdate(
 
   const params = {
     url: absoluteUrlForLocation(location),
-    urlref: !!prevLocation ? absoluteUrlForLocation(prevLocation) : ""
+    urlref: !!prevLocation ? absoluteUrlForLocation(prevLocation) : document.referrer
   };
 
   // wrap in a timeout to give metadata extraction and react-helmet time to execute

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -6,7 +6,7 @@ import React from "react";
 import { getOptions } from "./utils";
 
 exports.onRenderBody = function handleRenderBody(
-  { setHeadComponents },
+  { setPostBodyComponents },
   pluginOptions
 ) {
   const options = getOptions(pluginOptions);
@@ -16,7 +16,7 @@ exports.onRenderBody = function handleRenderBody(
     // pixelHost needs double-quotes because of how it'll be embedded.
     const pixelHost = options.pixelHost ? `"${options.pixelHost}"` : null;
 
-    return setHeadComponents([
+    return setPostBodyComponents([
       <script
         key="gatsby-plugin-parsely-analytics"
         id="parsely-cfg"


### PR DESCRIPTION
@mraakashshah and I noticed that Parsely's search referrers were way down, and it looks like prevLocation in gatsby doesn't work quite the way we thought it did: this PR makes sure that if prevLocation is null, we check document.referrer for urlref so we don't lose out on external referrers in cases where prevLocation is null. 

This PR also puts JS in the body, not the head, as per our docs